### PR TITLE
fix: Disable unimplemented toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Requirements:
    npm run ionic:android
    ```
 
+> NOTE: To connect to the server running on local machine on Android emulator 
+please change [Client URL](https://github.com/aerogear/apollo-voyager-ionic-example/blob/master/src/app/services/voyager.service.ts#L42) from `localhost` to `10.0.2.2` 
+
 ### Demo
 
 ![](./resources/screenshot.png)

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -30,7 +30,7 @@
               {{ item.description }}
             </ion-note>
           </ion-label>
-          <ion-toggle item-end style="margin-left:5px;" color="secondary"></ion-toggle>
+          <!--<ion-toggle item-end style="margin-left:5px;" color="secondary"></ion-toggle>-->
           <ion-button item-end style="margin-left:5px;" color="primary" fill="outline" (click)="goToItem(item)">
             <ion-icon name="arrow-forward"></ion-icon> Update
           </ion-button>


### PR DESCRIPTION
Toggle could be used for tutorial, however we should not show that for the moment as it's confusing for users.
Added note for different IP to be used with Android emulator.