### PR TITLE
AEROGEAR-8399 Push server image to Docker

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "nodemon src/index.js"
+    "start": "nodemon src/index.js",
+    "push": "docker build . -t aerogear/voyager-server-example-task && docker push aerogear/voyager-server-example-task"
   },
   "license": "Apache 2.0",
   "dependencies": {


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-8399

Sample app's server image was already pushed to https://hub.docker.com/r/aerogear/voyager-server-example-task. I used that name in the NPM script.

